### PR TITLE
Specify encoding on NLP file ingestion

### DIFF
--- a/nlp/imdbSentiment.py
+++ b/nlp/imdbSentiment.py
@@ -35,7 +35,7 @@ def getInstanceList(instanceRoot):
 
 # This takes a path, reads in the text, and provides a valence score on every word in the text
 def getTextScores(path, analyzer=DEFAULT_VADER):
-    text = Path(path).read_text()
+    text = Path(path).read_text(encoding="utf8")
     # NLTK has tons of useful tools for natural language processing.
     # Splitting text up into sentences is the tip of the iceberg
     sentences = tokenize.sent_tokenize(text)


### PR DESCRIPTION
File "10267_7.txt" was throwing an error:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1899: character maps to <undefined>
